### PR TITLE
docs: add example for latest tag with dynamic condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,14 @@ tags: |
 * [`type=semver,pattern=...`](#typesemver)
 * [`type=match,pattern=...`](#typematch)
 
+For conditionally tagging with latest for a specific branch name, e.g. if your default branch name
+is not `master`, use `type=raw` with a boolean expression:
+
+```yaml
+tags: |
+  type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+```
+
 ### Global expressions
 
 The following [Handlebars template](https://handlebarsjs.com/guide/) expressions for `prefix`, `suffix` and `value`


### PR DESCRIPTION
Hey! I had the same problem as described in https://github.com/docker/metadata-action/issues/147 and felt it had a place in the readme to save the next person around some time.

Does it make sense to you, and do you think the note is placed at the right place?