### PR TITLE
ci: update json job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,14 +227,6 @@ jobs:
           echo "version=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}"
           echo "revision=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}"
           echo "created=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}"
-      -
-        name: JSON build arg
-        uses: docker/build-push-action@v3
-        with:
-          context: ./test
-          file: ./test/json.Dockerfile
-          build-args: |
-            BUILDINFO=${{ steps.meta.outputs.json }}
 
   docker-push:
     runs-on: ubuntu-latest

--- a/test/json.Dockerfile
+++ b/test/json.Dockerfile
@@ -1,6 +1,0 @@
-# syntax=docker/dockerfile:1
-FROM alpine
-RUN apk add --no-cache coreutils jq
-ARG BUILDINFO
-RUN printenv BUILDINFO
-RUN echo $BUILDINFO | jq


### PR DESCRIPTION
The step in the `json` job is no longer necessary since it is already done by the `output-env` job.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>