### PR TITLE
docs: fix env syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ So it can be used with our [Docker Build Push action](https://github.com/docker/
 - uses: docker/build-push-action@v4
   with:
     build-args: |
-      DOCKER_METADATA_OUTPUT_JSON
+      ${{ env.DOCKER_METADATA_OUTPUT_JSON }}
 ```
 
 ### environment variables


### PR DESCRIPTION
it seems the GHA env syntax is invalid in the example in README.