### PR TITLE
commit_date: code cleanup and readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ ___
     * [`{{base_ref}}`](#base_ref)
     * [`{{is_default_branch}}`](#is_default_branch)
     * [`{{date '<format>' tz='<timezone>'}}`](#date-format-tztimezone)
+    * [`{{commit_date '<format>' tz='<timezone>'}}`](#commit_date-format-tztimezone)
   * [Major version zero](#major-version-zero)
   * [JSON output object](#json-output-object)
   * [Overwrite labels and annotations](#overwrite-labels-and-annotations)
@@ -891,13 +892,14 @@ Default `tz` is UTC.
 
 #### `{{commit_date '<format>' tz='<timezone>'}}`
 
-Returns the date when current git commit is committed.
-rendered by its [moment format](https://momentjs.com/docs/#/displaying/format/).
+Returns the date when the current git commit is committed, rendered by its
+[moment format](https://momentjs.com/docs/#/displaying/format/). It falls back
+to the current date if the commit date is not available.
 
 Default `tz` is UTC.
 
-| Expression                                   | Output example                          |
-|----------------------------------------------|-----------------------------------------|
+| Expression                                          | Output example                          |
+|-----------------------------------------------------|-----------------------------------------|
 | `{{commit_date 'YYYYMMDD'}}`                        | `20200110`                              |
 | `{{commit_date 'dddd, MMMM Do YYYY, h:mm:ss a'}}`   | `Friday, January 10th 2020, 3:25:50 pm` |
 | `{{commit_date 'YYYYMMDD-HHmmss' tz='Asia/Tokyo'}}` | `20200110-093000`                       |

--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -5,9 +5,9 @@ import * as path from 'path';
 import {Context} from '@actions/github/lib/context';
 import {Git} from '@docker/actions-toolkit/lib/git';
 import {GitHub} from '@docker/actions-toolkit/lib/github';
+import {Toolkit} from '@docker/actions-toolkit/lib/toolkit';
 
 import {ContextSource, getContext, getInputs, Inputs} from '../src/context';
-import {Toolkit} from '@docker/actions-toolkit/lib/toolkit';
 
 const toolkit = new Toolkit({githubToken: 'fake-github-token'});
 

--- a/__tests__/meta.test.ts
+++ b/__tests__/meta.test.ts
@@ -2,10 +2,11 @@ import {beforeEach, describe, expect, jest, test} from '@jest/globals';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as dotenv from 'dotenv';
+
+import {Context} from '@actions/github/lib/context';
 import {GitHub} from '@docker/actions-toolkit/lib/github';
 import {Toolkit} from '@docker/actions-toolkit/lib/toolkit';
 import {GitHubRepo} from '@docker/actions-toolkit/lib/types/github';
-import {Context} from '@actions/github/lib/context';
 
 import {ContextSource, getContext, getInputs, Inputs} from '../src/context';
 import {Meta, Version} from '../src/meta';


### PR DESCRIPTION
follow-up https://github.com/docker/metadata-action/pull/471#issuecomment-2484265272

@trim2 Fyi, I see in response schema that `commit.committer` for `/repos/{owner}/{repo}/commits/{ref}`: https://docs.github.com/en/rest/commits/commits?apiVersion=2022-11-28#get-a-commit

Can be null:

```json
        "committer": {
          "anyOf": [
            {
              "type": "null"
            },
            {
              "title": "Git User",
              "description": "Metaproperties for Git author/committer information.",
              "type": "object",
              "properties": {
                "name": {
                  "type": "string",
                  "examples": [
                    "\"Chris Wanstrath\""
                  ]
                },
                "email": {
                  "type": "string",
                  "examples": [
                    "\"chris@ozmm.org\""
                  ]
                },
                "date": {
                  "type": "string",
                  "examples": [
                    "\"2007-10-29T02:42:39.000-07:00\""
                  ]
                }
              }
            }
          ]
        },
```

If that happens it would just return the current date. I think that's fine but we could improve that as follow-up. Probably warn if that happens.