### PR TITLE
docs(README): clarify how `tags:` set `version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,7 +794,7 @@ tags: |
 ### `priority` attribute
 
 `priority=<int>` attribute is used to sort tags in the final list. The higher
-the value, the higher the priority. The first tag in the list (higher priority)
+the value, the higher the priority. The highest-priority tag in the `tags` input list
 will be used as the image version for generated OCI label and [`version` output](#outputs).
 Each tags `type` attribute has a default priority:
 


### PR DESCRIPTION
## Description

Closes https://github.com/docker/metadata-action/issues/561

The [README says](https://github.com/docker/metadata-action?tab=readme-ov-file#priority-attribute),

> The first tag in the list (higher priority) will be used as the image version for generated OCI label and [`version` output](https://github.com/docker/metadata-action?tab=readme-ov-file#outputs).

That doesn't seem to be correct.

Example run [here](https://github.com/br3ndonland/dovi_tool/actions/runs/19317960263).

Workflow file had `type=sha` listed first:

```yaml
- name: Set up metadata
  id: meta
  uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
  with:
    images: ghcr.io/${{ github.repository }}
    flavor: |
      latest=${{ github.ref_type == 'tag' || github.ref_name == 'main' }}
    tags: |
      type=sha
      type=ref,event=branch
```

But then the action output was `org.opencontainers.image.version=main`.

<img width="75%" alt="Screenshot of GitHub Actions workflow run logs showing that the version label was not assigned based on list order" src="https://github.com/user-attachments/assets/b5cda9ed-ba4a-418b-b4e7-a7a76e8eb786" />

## Changes

This PR will update the wording in the README to clarify that `version` is determined by the highest-priority tag in the `tags:` input list, regardless of the order of the items in the input.
