### PR TITLE
docs(README): Fix date format from 12h to 24h in schedule pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ tags: |
   # handlebars
   type=schedule,pattern={{date 'YYYYMMDD'}}
   # handlebars with timezone
-  type=schedule,pattern={{date 'YYYYMMDD-hhmmss' tz='Asia/Tokyo'}}
+  type=schedule,pattern={{date 'YYYYMMDD-HHmmss' tz='Asia/Tokyo'}}
 ```
 
 Will be used on [schedule event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule).


### PR DESCRIPTION
hh represents 12h format from 01 to 12 which is probably not suitable for date tags.
The pattern example in the table below uses the 24h format HH, so this makes the document consistent.

Feel free to correct me if this was actually intentional!

https://momentjs.com/docs/#/displaying/format/