### PR TITLE
docs: explain how onlatest works

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ flavor: |
 * `suffix=<string>,onlatest=<false|true>`: A global suffix for each generated
   tag.
 
-The `prefix` and `suffix` flavor settings can set `onlatest=true` (default: `false`) to additionally apply the affix to the [`latest` tag](#latest-tag) (_when it is added via the `flavor.latest` condition_).
+The `prefix` and `suffix` flavor settings can set `onlatest=true` (default: `false`) to additionally apply the affix to the [`latest` tag](#latest-tag) (_when it is added via the `flavor.latest` condition_). See also [this comment](https://github.com/docker/metadata-action/issues/567#issuecomment-3579068205) for more info.
 
 ## `tags` input
 


### PR DESCRIPTION
This bit would have let me avoid having to file https://github.com/docker/metadata-action/issues/567

Fixes: #567