### PR TITLE
docs: update checkout action to v6 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       -
         name: Docker meta
         id: meta
@@ -131,7 +131,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       -
         name: Docker meta
         id: meta


### PR DESCRIPTION
Updates the README workflow examples to use `actions/checkout@v6` instead of `@v5`.