### PR TITLE
ci: stop update-dist reruns after generated dist pushes

### DIFF
--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   update-dist:
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == github.event.pull_request.head.repo.full_name
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == github.event.pull_request.head.repo.full_name
     runs-on: ubuntu-latest
     steps:
       -


### PR DESCRIPTION
similar to https://github.com/docker/bake-action/pull/415